### PR TITLE
fix: Add browserslist to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,17 @@
     "recharts": "^3.1.2",
     "tailwindcss": "^4.1.12",
     "typescript": "^4.9.5"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
This prevents the "We're unable to detect target browsers" prompt from appearing when running `npm start`.